### PR TITLE
Add new main branch URL request after a failed request 

### DIFF
--- a/terraform-doc.el
+++ b/terraform-doc.el
@@ -95,8 +95,8 @@
       (let ((content))
         (dolist (url '("d" "r"))
           (with-current-buffer
-              (url-retrieve-synchronously
-               (format "https://github.com/terraform-providers/terraform-provider-%s/file-list/master/website/docs/%s" provider url))
+	    (terraform-doc-get-url provider "master" url)
+	    (if (string= "HTTP/1.1 404" (buffer-substring 1 13)) (switch-to-buffer (terraform-doc-get-url provider "main" url)))
             (goto-char (point-min))
             (search-forward-regexp "\n\n" )
             (delete-region (point) (point-min))
@@ -145,6 +145,10 @@
              (markdown-mode))
          (setq buffer-read-only t)
          (switch-to-buffer (current-buffer))))))))
+
+(defun terraform-doc-get-url (provider branch url)
+  (setq outbuff (url-retrieve-synchronously
+   (format "https://github.com/terraform-providers/terraform-provider-%s/file-list/%s/website/docs/%s" provider branch url))))
 
 (defun terraform-doc-mode-on ()
   "Render and switch to ‘terraform-doc’ mode."


### PR DESCRIPTION
## What
Make another URL request to the `main` branch of a repository for Terraform provider repositories that do not have a branch named `master`. A Terraform provider repository is determined to not have a `master` branch if the buffer output of the first 13 characters of the first request are equal to "HTTP/1.1 404".

## Why

The URL request currently made is hardcoded to look at the `master` branch. Terraform provider repositories that do not have a branch named `master` will fail to retrieve the documentation.

For example, the [terraform-provider-azurerm](https://github.com/hashicorp/terraform-provider-azurerm) provider has a default branch of `main` and the current version of this package cannot pull up any `azurerm` documentation.

## Notes
A better solution would have involved making a Github API request to the determine the default branch of the repository such as the following:

```elisp
(defun terraform-doc-get-default-branch (provider)
  (setq request_url (format "https://api.github.com/repos/hashicorp/terraform-provider-%s" provider))
  (message "%s" request_url)
  (request request_url
           :sync t
           :parser 'json-read
           :complete (cl-function
                      (lambda (&key response &allow-other-keys)
                        (setq out (cdr (assoc 'default_branch (request-response-data response))))))))
```

However the Github API rate limits (https://docs.github.com/en/developers/apps/building-github-apps/rate-limits-for-github-apps) keep this from being realistic. As a result, I settled for assuming that either `master` or `main` will be the appropriate branch for the Terraform provider repositories.
