### PR TITLE
md-mode: Use customizable variable for the markdown mode

### DIFF
--- a/terraform-doc.el
+++ b/terraform-doc.el
@@ -45,6 +45,11 @@
   :type 'string
   :group 'terraform)
 
+(defcustom terraform-doc-markdown-mode-function 'markdown-mode
+  "*Function to use for markdown rendering in `terraform-doc', e.g. `markdown-mode' or `gfm-view-mode'."
+  :type 'function
+  :group 'terraform)
+
 (defvar terraform-doc-mode-map
   (let ((keymap (make-sparse-keymap)))
     (define-key keymap (kbd "o") 'terraform-doc-at-point)
@@ -140,8 +145,8 @@
          (search-forward-regexp "\n\n" )
          (delete-region (point) (point-min))
          (rename-buffer buffer-name)
-         (if (fboundp 'markdown-mode)
-             (markdown-mode))
+         (if (fboundp terraform-doc-markdown-mode-function)
+             (funcall terraform-doc-markdown-mode-function))
          (setq buffer-read-only t)
          (switch-to-buffer (current-buffer))))))))
 


### PR DESCRIPTION
## What is it?

This PR introduces a new variable `terraform-doc-markdown-mode-function` which makes it possible to configure which Markdown mode to use when displaying the documentation for an item. The default is the current one used: `markdown-mode`.


## Why?

I found that the `gfm-mode` renders the Markdown used for the documentation better. In particular it is more robust when it comes to render `snake_case_symbols` without "case" being in italics. (`gfm-mode` might be a better default value for this reason).

I also found it nicer to display the documentation (which I'm only interested in reading, rather than editing) using the `gfm-view-mode`.

So now those things are configurable.
